### PR TITLE
fix: shell bugs and hardening on dev branch

### DIFF
--- a/scripts/bmConfigborne.sh
+++ b/scripts/bmConfigborne.sh
@@ -79,9 +79,9 @@ fi
 	echo "# Mise à jour" ; apt install -f
 	echo "60" ; sleep 1
 	echo "# Maj Solibuntu"
-	echo "90" ;
+		echo "90" ;
 		# Lance le script d'installation
-		cd /Solibuntu
+		cd "$repinstallation/scripts"
 		./install.sh maj
 	echo "# Mise à jour" ; apt autoremove --purge -y
 	echo "95" ; sleep 1

--- a/scripts/bmConnectusb.sh
+++ b/scripts/bmConnectusb.sh
@@ -107,8 +107,9 @@ while [ $ret -ne 0 ]
 
 			# Teste si le mot de passe correspond au compte "gestionnaire"
 			testMdp $user $pass
+			mdp_gest=$?
 
-			if [ $? == 0 ];then
+			if [ $mdp_gest -eq 0 ]; then
 
 				# Teste si le mot de passe du gestionnaire est celui par défaut
 				if [ $pass == "AdminAsso" ] ; then
@@ -134,7 +135,7 @@ jamais été changé. Veuillez le signaler à l'administrateur de Solibuntu."
 				fi
 				# Appel le script du panneau de configuration en indiquant le compte gestionnaire
 				$repinstallation/scripts/bmConfigborne.sh gestionnaire
-			elif [ $? == 1 ];then
+			elif [ $mdp_gest -eq 1 ]; then
 				# Teste si le mot de passe est celui du compte administrateur
 				user="administrateur"
 				testMdp $user $pass

--- a/scripts/bmLib.sh
+++ b/scripts/bmLib.sh
@@ -86,9 +86,17 @@ getDateTime() {
 # Cree un identifiant unique a partir de l'adresse MAC de la carte reseau
 # et l'encode en Base 64
 getUniqID() {
-    mac="`/sbin/ifconfig | grep enp | grep HWaddr | awk '{print $NF}' | sed -e 's/:/_/g'`"
-    mac64=`echo "${mac}" | base64 -`
-    #nohup xterm &
+    mac=""
+    if command -v ip >/dev/null 2>&1; then
+        mac=$(ip link show 2>/dev/null | awk '/link\/ether/ {gsub(/.*ether /, ""); print $1; exit}' | sed -e 's/:/_/g')
+    fi
+    if [ -z "$mac" ] && [ -x /sbin/ifconfig ]; then
+        mac=$(/sbin/ifconfig 2>/dev/null | awk '/ether|HWaddr/ {for (i=1;i<=NF;i++) if ($i ~ /^([0-9a-f]{2}:){5}/) {print $i; exit}}' | sed -e 's/:/_/g')
+    fi
+    if [ -z "$mac" ]; then
+        mac="unknown"
+    fi
+    mac64=$(printf '%s' "${mac}" | base64 -w0 2>/dev/null || printf '%s' "${mac}" | base64)
     echo "${mac64}"
 }
 
@@ -156,10 +164,11 @@ testDispo() {
     utilisateur="administrateur"
     pass=$1
     testMdp $utilisateur $pass
-    if [ $? == 0 ]; then
+    mdp_admin=$?
+    if [ $mdp_admin -eq 0 ]; then
         # Le mot de passe est celui de l'administrateur
         return 1
-    elif [ $? == 1 ]; then
+    elif [ $mdp_admin -eq 1 ]; then
         # Le mot de passe n'est pas celui de l'administrateur
         return 0
     fi
@@ -260,7 +269,7 @@ En cas de perte ou d’oubli du mot de passe de l’administrateur, il sera néc
             passVerif=`echo $entr | cut -d'|' -f2`
             if [ $pass == $passVerif ] ; then
                 testSecu $pass
-                if [ 0 == 0 ]; then
+                if [ $? -eq 0 ]; then
                     zenity --question --width=300 --text "Voulez-vous vraiment modifier le mot de passe $1 ?"
                     if [ $? == 0 ] ; then
                         if [ $pass != "" ] ; then

--- a/scripts/filtrage_install.sh
+++ b/scripts/filtrage_install.sh
@@ -33,6 +33,8 @@ repinstallation="/opt/borne"
 
 [ `whoami` = root ] || { gksudo "$0" "$@"; exit $?; }
 
+result_file=$(mktemp)
+trap 'rm -f "$result_file"' EXIT
 (
 	echo "10" ; sleep 1
 	echo "# Vérification des mises à jour" ; sudo apt update
@@ -46,7 +48,7 @@ repinstallation="/opt/borne"
 	#echo "# Installation des dépendances"; sudo apt-get install -y clamav clamav-base clamav-freshclam console-data dansguardian dnsmasq gamin iptables-persistent libclamav7 libgamin0 libllvm3.6v5 liblua5.1-0 libnss3-tools lighttpd lighttpd-mod-magnet netfilter-persistent php-cgi php-common php-xml php7.0-cgi php7.0-cli php7.0-common php7.0-json php7.0-opcache php7.0-readline php7.0-xml privoxy spawn-fcgi
 	#echo "60" ; sleep 1
 	echo "# Installation filtrage"; installFiltrage
-	result=$?
+	echo $? > "$result_file"
 	echo "70" ; sleep 1
 	#echo "# Configuation du proxy" ; sudo cp -rf /opt/borne/share/proxy/defaulton /etc/chromium-browser/default
 	echo "80" ; sleep 1
@@ -62,8 +64,8 @@ repinstallation="/opt/borne"
 	#if [ "$?" = -1 ] ; then
 	#	zenity --error --text="Installation annulée."
 	#fi
-	return $result
-exit 0
+	result=$(cat "$result_file")
+	exit "${result:-1}"
 
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,11 +8,14 @@
 
 repinstallation="/opt/borne"
 
-if [ $1 == "installation" ] ; then
-	groupadd Solibuntu
-	useradd root Solibuntu
-	useradd administrateur Solibuntu
-	useradd gestionnaire Solibuntu
+if [ "$1" = "installation" ] ; then
+	getent group Solibuntu >/dev/null 2>&1 || groupadd Solibuntu
+	if ! id -u administrateur >/dev/null 2>&1; then
+		useradd -m -g Solibuntu administrateur
+	fi
+	if ! id -u gestionnaire >/dev/null 2>&1; then
+		useradd -m -g Solibuntu gestionnaire
+	fi
 	chgrp Solibuntu /root/
 	chmod 774 /root/
 fi
@@ -84,7 +87,7 @@ if [ $? == 0 ] ; then
 
 	echo "Installation logicielle"
 	apt-get update
-	if [ $1 != "iso" ] ; then
+	if [ "$1" != "iso" ] ; then
 		apt-get full-upgrade -y && apt install -f && apt-get clean
 	fi
 
@@ -111,8 +114,8 @@ if [ $? == 0 ] ; then
 
 
 	# Désinstallation des extensions de Thunar Ouvrir dans un terminal etc.
-	if [ $1 != "iso" ] ; then
-		dconf write /org/mate/caja/extensions/disabled-extensions "['libcaja-main-menu,'libcaja-sento','libcaja-python','libcaja-pythin','libcaja-wallpaper','libcaja-gksu','libcaja-engrampa','libcaja-open-terminal','libcatril-properties-page']"
+	if [ "$1" != "iso" ] ; then
+		dconf write /org/mate/caja/extensions/disabled-extensions "['libcaja-main-menu,'libcaja-sento','libcaja-python','libcaja-pythin','libcaja-wallpaper','libcaja-gksu','libcaja-engrampa','libcaja-open-terminal','libcatril-properties-page']" 2>/dev/null || true
 		apt-get install printer-driver-cups-pdf
 	fi
 
@@ -169,7 +172,7 @@ if [ $? == 0 ] ; then
 	cp /opt/borne/scripts/sessionStart.desktop /etc/xdg/autostart/sessionStart.desktop
 
 	#Copie des profils
-	if [ $1 != "maj" ] ; then
+	if [ "$1" != "maj" ] ; then
 		cp /opt/borne/share/skel_admin.tar.gz /home/
 		cp /opt/borne/share/skel_gest.tar.gz /home/
 		cd /home/

--- a/scripts/sessionStart.sh
+++ b/scripts/sessionStart.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 touch /tmp/sessionstarted
 
-if [ $USER == "administrateur" -o $USER == "gestionnaire" ] ; then
-	echo "1" > /root/.lastadminlogin
+if [ "$USER" = "administrateur" ] || [ "$USER" = "gestionnaire" ]; then
+	echo "1" | sudo -n /usr/bin/tee /root/.lastadminlogin >/dev/null || true
 fi

--- a/share/sudoers
+++ b/share/sudoers
@@ -18,7 +18,9 @@ Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/b
 
 # User privilege specification
 root	ALL=(ALL:ALL) ALL
+administrateur	ALL=(root) NOPASSWD: /usr/bin/tee /root/.lastadminlogin
 gestionnaire	ALL=(ALL:ALL) /usr/bin/apt,/usr/bin/apt-get,/usr/sbin/aptd,/usr/bin/gnome-software,/usr/bin/CTparental
+gestionnaire	ALL=(root) NOPASSWD: /usr/bin/tee /root/.lastadminlogin
 
 # Members of the admin group may gain root privileges
 %admin ALL=(ALL) ALL


### PR DESCRIPTION
- install.sh: valid useradd/groupadd for administrateur/gestionnaire; quote \
- bmLib.sh: testDispo and changerMdp capture \True; getUniqID uses ip then ifconfig
- bmConnectusb.sh: save testMdp exit code before branching to administrateur
- filtrage_install.sh: persist install exit code from subshell via temp file
- sessionStart.sh: write lastadminlogin via sudo tee; sudoers NOPASSWD for tee
- bmConfigborne.sh: run install.sh maj from /opt/borne/scripts
- install.sh: ignore dconf failure on non-MATE systems